### PR TITLE
Fix lost styling: deploy Next.js CSS/JS/font assets to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,8 @@ jobs:
     - run: npm run build
     - run: ls -l out
 
-    - run: npm run upload-static
+    # Upload immutable, content-hashed assets (CSS/JS/fonts) first, then the
+    # HTML that references them, so the site is never served with stale HTML
+    # pointing at assets that don't exist yet.
+    - run: npm run upload-assets
+    - run: npm run upload-html

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "next build",
     "lint": "eslint .",
     "test": "vitest run",
-    "upload-static": "aws s3 sync out/ s3://weygand-dev-2409654 --cache-control 'public, max-age=600' --exclude '*' --include '*.html'"
+    "upload-assets": "aws s3 sync out/ s3://weygand-dev-2409654 --delete --cache-control 'public, max-age=31536000, immutable' --exclude '*.html'",
+    "upload-html": "aws s3 sync out/ s3://weygand-dev-2409654 --cache-control 'public, max-age=600' --exclude '*' --include '*.html'",
+    "upload-static": "npm run upload-assets && npm run upload-html"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
## Problem

Styling was lost on the deployed site after the Next.js static-export migration (`d2d5e48`). The **build is fine** — a local `next build` renders the resume with correct fonts, two-column layout, borders, and list styling. The regression is entirely in **deployment**.

## Root cause

The pre-migration site (CRA + hand-rolled `ReactDOMServer` prerender with **styled-components**) inlined all CSS into the HTML `<head>` and loaded fonts from Google's CDN. A deploy that uploaded **only HTML** was therefore self-sufficient.

The migration switched to **CSS Modules** + self-hosted **`next/font`**, which emit separate content-hashed files under `out/_next/static/` (CSS, JS, fonts). But the deploy script was carried over unchanged:

```
aws s3 sync out/ ... --exclude '*' --include '*.html'
```

It uploads **only `*.html`**, so the deployed HTML references `/_next/static/` assets that were never uploaded to S3 → every stylesheet/font 404s → all styling lost.

## Fix

Restore the two-phase upload the pre-migration project already used (`upload` + `upload-html`), adapted to Next.js's `out/`:

- **`upload-assets`** — syncs everything except HTML (CSS/JS/fonts/icons) with a long immutable cache, `--delete` to prune stale hashed files.
- **`upload-html`** — syncs only HTML with a short cache.
- **`upload-static`** now runs assets → HTML in order.
- The workflow runs the two phases explicitly so HTML never points at not-yet-uploaded assets.

## Reviewer notes

- No application code changed — only `package.json` scripts and the release workflow.
- Verify the `AWS_ACCESS_KEY_ID` repo secret from the migration is in place; the upload step needs it.
- Once merged to `master`, the next CI run publishes the CSS/JS/fonts and the live site's styling will match the local build.